### PR TITLE
Actions on content packages - use table?

### DIFF
--- a/docs/30-ContentPackages/creating-a-content-package-9027b86.md
+++ b/docs/30-ContentPackages/creating-a-content-package-9027b86.md
@@ -140,7 +140,7 @@ You’ve created a dev space with the *Development Tools for SAP Build Work Zone
 
     You’ve successfully created a project that contains the required content package. The newly created content package is now available in your workspace. You can now perform the following actions on your content package:
     
-    | Action for content package |   Documentation |
+    | Action for content package |   More Information |
     |:---|:---|
     | Update | [Updating a Content Package](updating-a-content-package-de85e4f.md) |
     | Deploy | [Deploying a Content Package](deploying-a-content-package-5556cbf.md) |

--- a/docs/30-ContentPackages/creating-a-content-package-9027b86.md
+++ b/docs/30-ContentPackages/creating-a-content-package-9027b86.md
@@ -138,11 +138,13 @@ You’ve created a dev space with the *Development Tools for SAP Build Work Zone
     
 5.  Choose *Finish*.
 
-    You’ve successfully created a project that contains the required content package. The newly created content package is now available in your workspace. You can now perform the following:
-
-    -   Update the content package: For more information, see [Updating a Content Package](updating-a-content-package-de85e4f.md)
-    -   Delete the content package: To do so, navigate to the newly created card project. Right-click on the project and select *Delete*.
-    -   Deploy the content package: For more information, see [Deploying a Content Package](deploying-a-content-package-5556cbf.md)
+    You’ve successfully created a project that contains the required content package. The newly created content package is now available in your workspace. You can now perform the following actions on your content package:
+    
+    | Action for content package |   Documentation |
+    |:---|:---|
+    | Update | [Updating a Content Package](updating-a-content-package-de85e4f.md) |
+    | Deploy | [Deploying a Content Package](deploying-a-content-package-5556cbf.md) |
+    | Delete | Navigate to the newly created card project. Right-click on the project and select *Delete*. |
 
     You can also execute `Content Package: Create Content Package Project` to launch a command line interface for creating content package.
 


### PR DESCRIPTION
I think using a table may make it easier to follow this step. Since the content package was just created, I assume "Delete" may be the last thing someone wants to do, so I put it at the end. Or is the order like that on the UI (Update, Delete, Deploy)?